### PR TITLE
Add promises in a backwards-compatible way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+index.d.ts

--- a/README.md
+++ b/README.md
@@ -18,4 +18,9 @@ expand(el, () => {
   // callback for when the element is fully transitioned
   // you can emit events from here, or target content inside 'el'
 })
+
+// or async
+
+await expand(el)
+// do your after-transition stuff here!
 ```

--- a/index.html
+++ b/index.html
@@ -13,11 +13,16 @@
     <div id="target-two">
       <div class="bg-blue-500 p-32"><h1>Content Two</h1></div>
     </div>
-    <button id="button-two">Toggle two</button>
+    <div class="flex flex-col">
+      <button id="button-two">Toggle two</button>
+      <button id="expand-one">Expand one</button>
+      <button id="collapse-one">Collapse one</button>
+    </div>
     <script type="module">
       import * as operations from './index.js'
 
       let twoIsCollapsed = false
+      const one = document.querySelector('#target-one')
       const two = document.querySelector('#target-two')
 
       function toggleTwo() {
@@ -25,7 +30,17 @@
         twoIsCollapsed = !twoIsCollapsed;
       }
 
+      async function expandOne() {
+        await operations.expand(one)
+        console.log("Expand completed")
+      }
+      function collapseOne() {
+        operations.collapse(one)
+      }
+
       document.querySelector('#button-two').addEventListener('click', toggleTwo)
+      document.querySelector('#collapse-one').addEventListener('click', collapseOne)
+      document.querySelector('#expand-one').addEventListener('click', expandOne)
     </script>
   </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -37,7 +37,8 @@ const getAfterCollapseCallback = (done) => () => {
 
 /**
  * Transitions an element from 0 to a detected height
- * @type {(el: HTMLElement, done?: function) => void | Promise}
+ * Will return a Promise when no 'done' callback is provided
+ * @type {(el: HTMLElement, done?: function) => void | Promise<void>}
  */
 export const expand = (el, done) => {
   const returnPromise = (() => {
@@ -59,7 +60,8 @@ export const expand = (el, done) => {
 
 /**
  * Transitions an element from a detected height to 0
- * @type {(el: HTMLElement, done?: function) => void | Promise}
+ * Will return a Promise when no 'done' callback is provided
+ * @type {(el: HTMLElement, done?: function) => void | Promise<void>}
  */
 export const collapse = (el, done) => {
   const returnPromise = (() => {

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const getAfterCollapseCallback = (done) => () => {
 
 /**
  * Transitions an element from 0 to a detected height
- * @type {(el: HTMLElement, done?: function) => void}
+ * @type {(el: HTMLElement, done?: function) => void | Promise}
  */
 export const expand = (el, done) => {
   const returnPromise = (() => {
@@ -59,7 +59,7 @@ export const expand = (el, done) => {
 
 /**
  * Transitions an element from a detected height to 0
- * @type {(el: HTMLElement, done?: function) => void}
+ * @type {(el: HTMLElement, done?: function) => void | Promise}
  */
 export const collapse = (el, done) => {
   const returnPromise = (() => {

--- a/index.js
+++ b/index.js
@@ -40,6 +40,9 @@ const getAfterCollapseCallback = (done) => () => {
  * @type {(el: HTMLElement, done?: function) => void}
  */
 export const expand = (el, done) => {
+  const returnPromise = (() => {
+    if (!done) return new Promise(r => { done = r })
+  })()
   const afterExpandCallback = getAfterExpandCallback(el, done)
   removeTransition(el)
   el.style.height = 'auto'
@@ -51,6 +54,7 @@ export const expand = (el, done) => {
     addTransition(el)
     requestAnimationFrame(() => el.style.height = dest + 'px')
   })
+  if (returnPromise) return returnPromise
 }
 
 /**
@@ -58,6 +62,9 @@ export const expand = (el, done) => {
  * @type {(el: HTMLElement, done?: function) => void}
  */
 export const collapse = (el, done) => {
+  const returnPromise = (() => {
+    if (!done) return new Promise(r => { done = r })
+  })()
   const afterCollapseCallback = getAfterCollapseCallback(done)
   removeTransition(el)
   let original = el.scrollHeight
@@ -68,4 +75,5 @@ export const collapse = (el, done) => {
     addTransition(el)
     requestAnimationFrame(() => el.style.height = '0px')
   })
+  if (returnPromise) return returnPromise
 }

--- a/package.json
+++ b/package.json
@@ -4,14 +4,19 @@
   "description": "pure JS hooks to animate the expand/collapse of an element",
   "type": "module",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "https://github.com/finn-no/element-collapse",
   "author": "Dave Honneffer",
   "license": "MIT",
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ],
   "scripts": {
     "dev": "vite",
     "test": "node test/test",
     "test:e2e": "yarn cypress open",
-    "preversion": "yarn test",
+    "preversion": "yarn test && tsc",
     "version": "npm publish",
     "postversion": "git push --follow-tags"
   },
@@ -20,6 +25,7 @@
     "drnm": "^0.9.0",
     "fastify": "^3.19.2",
     "fastify-static": "^4.2.2",
+    "typescript": "^4.7.2",
     "vite": "^2.6.10"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["index.js"],
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowJs": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+typescript@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
+  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"


### PR DESCRIPTION
As mentioned in the [React expandable improvement PR](https://github.com/fabric-ds/react/commit/075f314adfa468960a42f7c87af855d2f1ddce6d#diff-17fcd08f742dff050799a24353a81f3aa48d0e7accdaced77fc423ff0249a754R14), this adds support for promises when no `done` callback is received